### PR TITLE
add macOS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,32 +4,45 @@ PREFIX ?= /usr
 NAME = frei
 OUT_DIR = build
 
-TARGET_OS = linux
 VERSION = $(shell git describe --tags --abbrev=0)
 COMMIT = $(shell git rev-list -1 HEAD)
 
-build: amd64 386 arm
+build: linux-amd64 linux-386 linux-arm darwin-amd64 darwin-arm64
 
-amd64:
-	@echo "building amd64"
-	GOOS=$(TARGET_OS) GOARCH=amd64 \
+linux-amd64:
+	@echo "building linux-amd64"
+	GOOS=linux GOARCH=amd64 \
 		go build \
 		-ldflags "-X main.Version=$(VERSION) -X main.CommitSHA=$(COMMIT)" \
-		-o "$(OUT_DIR)/$(NAME)-$(TARGET_OS)-amd64" .
+		-o "$(OUT_DIR)/$(NAME)-linux-amd64" .
 
-386:
-	@echo "building 386"
-	GOOS=$(TARGET_OS) GOARCH=386 \
+linux-386:
+	@echo "building linux-386"
+	GOOS=linux GOARCH=386 \
 		go build \
 		-ldflags "-X main.Version=$(VERSION) -X main.CommitSHA=$(COMMIT)" \
-		-o "$(OUT_DIR)/$(NAME)-$(TARGET_OS)-386" .
+		-o "$(OUT_DIR)/$(NAME)-linux-386" .
 
-arm:
-	@echo "building arm"
-	GOOS=$(TARGET_OS) GOARCH=arm \
+linux-arm:
+	@echo "building linux-arm"
+	GOOS=linux GOARCH=arm \
 		go build \
 		-ldflags "-X main.Version=$(VERSION) -X main.CommitSHA=$(COMMIT)" \
-		-o "$(OUT_DIR)/$(NAME)-$(TARGET_OS)-arm" .
+		-o "$(OUT_DIR)/$(NAME)-linux-arm" .
+
+darwin-amd64:
+	@echo "building darwin-amd64"
+	GOOS=darwin GOARCH=amd64 \
+		go build \
+		-ldflags "-X main.Version=$(VERSION) -X main.CommitSHA=$(COMMIT)" \
+		-o "$(OUT_DIR)/$(NAME)-darwin-amd64" .
+
+darwin-arm64:
+	@echo "building darwin-arm64"
+	GOOS=darwin GOARCH=arm64 \
+		go build \
+		-ldflags "-X main.Version=$(VERSION) -X main.CommitSHA=$(COMMIT)" \
+		-o "$(OUT_DIR)/$(NAME)-darwin-arm64" .
 
 clean:
 	$(RM) -r $(OUT_DIR)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/alexcoder04/frei
 
-go 1.18
+go 1.24.0
+
+require golang.org/x/sys v0.40.0
+
+require golang.org/x/term v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.39.0 h1:RclSuaJf32jOqZz74CkPA9qFuVTX7vhLlpfj/IGWlqY=
+golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=

--- a/mem_darwin.go
+++ b/mem_darwin.go
@@ -1,0 +1,114 @@
+//go:build darwin
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// GetMemInfo reads memory data from macOS system calls and vm_stat
+func GetMemInfo() (MemData, error) {
+	res := MemData{}
+
+	// Get total memory via sysctl
+	memSize, err := unix.SysctlUint64("hw.memsize")
+	if err != nil {
+		return res, fmt.Errorf("failed to get hw.memsize: %w", err)
+	}
+	// Convert bytes to KB (to match Linux format)
+	res.MemTotal = float64(memSize) / 1024
+
+	// Get page size
+	pageSize, err := unix.SysctlUint32("vm.pagesize")
+	if err != nil {
+		return res, fmt.Errorf("failed to get vm.pagesize: %w", err)
+	}
+
+	// Parse vm_stat output for detailed memory info
+	vmStats, err := getVMStats()
+	if err != nil {
+		return res, fmt.Errorf("failed to get vm_stat: %w", err)
+	}
+
+	// Convert page counts to KB
+	pageSizeKB := float64(pageSize) / 1024
+
+	pagesFree := vmStats["Pages free"] * pageSizeKB
+	pagesActive := vmStats["Pages active"] * pageSizeKB
+	pagesInactive := vmStats["Pages inactive"] * pageSizeKB
+	pagesSpeculative := vmStats["Pages speculative"] * pageSizeKB
+	pagesWired := vmStats["Pages wired down"] * pageSizeKB
+	pagesCompressed := vmStats["Pages occupied by compressor"] * pageSizeKB
+	pagesPurgeable := vmStats["Pages purgeable"] * pageSizeKB
+
+	res.MemFree = pagesFree
+	res.MemUsed = pagesActive + pagesWired + pagesCompressed
+	res.MemCached = pagesInactive + pagesSpeculative + pagesPurgeable
+	res.MemBuffers = 0 // No direct equivalent on macOS
+	res.MemAvailable = pagesFree + pagesInactive + pagesSpeculative + pagesPurgeable
+	res.MemShared = 0 // Would require additional parsing
+
+	// Get swap info via sysctl
+	swapUsage, err := unix.SysctlRaw("vm.swapusage")
+	if err == nil && len(swapUsage) >= 24 {
+		// struct xsw_usage { uint64_t xsu_total, xsu_avail, xsu_used; }
+		swapTotal := *(*uint64)(unsafe.Pointer(&swapUsage[0]))
+		swapAvail := *(*uint64)(unsafe.Pointer(&swapUsage[8]))
+		swapUsed := *(*uint64)(unsafe.Pointer(&swapUsage[16]))
+
+		res.SwapTotal = float64(swapTotal) / 1024
+		res.SwapFree = float64(swapAvail) / 1024
+		res.SwapUsed = float64(swapUsed) / 1024
+	}
+
+	if res.MemTotal <= 0 {
+		fmt.Println("Error: your total installed memory appears to be 0 or less.")
+		os.Exit(1)
+	}
+
+	return res, nil
+}
+
+// getVMStats parses the output of vm_stat command
+func getVMStats() (map[string]float64, error) {
+	stats := make(map[string]float64)
+
+	cmd := exec.Command("vm_stat")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip header line
+		if strings.HasPrefix(line, "Mach Virtual Memory Statistics") {
+			continue
+		}
+		// Parse lines like: "Pages free:                             1234."
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		valueStr := strings.TrimSpace(parts[1])
+		valueStr = strings.TrimSuffix(valueStr, ".")
+
+		value, err := strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			continue
+		}
+		stats[key] = value
+	}
+
+	return stats, nil
+}

--- a/mem_darwin_test.go
+++ b/mem_darwin_test.go
@@ -1,0 +1,116 @@
+//go:build darwin
+
+package main
+
+import (
+	"testing"
+)
+
+func TestGetMemInfo(t *testing.T) {
+	data, err := GetMemInfo()
+	if err != nil {
+		t.Fatalf("GetMemInfo() returned error: %v", err)
+	}
+
+	// MemTotal should be positive (system has memory)
+	if data.MemTotal <= 0 {
+		t.Errorf("MemTotal should be positive, got %f", data.MemTotal)
+	}
+
+	// MemUsed should be positive (some memory is always in use)
+	if data.MemUsed <= 0 {
+		t.Errorf("MemUsed should be positive, got %f", data.MemUsed)
+	}
+
+	// MemUsed should be less than MemTotal
+	if data.MemUsed >= data.MemTotal {
+		t.Errorf("MemUsed (%f) should be less than MemTotal (%f)", data.MemUsed, data.MemTotal)
+	}
+
+	// MemFree should be non-negative
+	if data.MemFree < 0 {
+		t.Errorf("MemFree should be non-negative, got %f", data.MemFree)
+	}
+
+	// MemAvailable should be positive and less than or equal to MemTotal
+	if data.MemAvailable <= 0 {
+		t.Errorf("MemAvailable should be positive, got %f", data.MemAvailable)
+	}
+	if data.MemAvailable > data.MemTotal {
+		t.Errorf("MemAvailable (%f) should not exceed MemTotal (%f)", data.MemAvailable, data.MemTotal)
+	}
+
+	// MemCached should be non-negative
+	if data.MemCached < 0 {
+		t.Errorf("MemCached should be non-negative, got %f", data.MemCached)
+	}
+
+	// MemBuffers is always 0 on macOS, but should be non-negative
+	if data.MemBuffers < 0 {
+		t.Errorf("MemBuffers should be non-negative, got %f", data.MemBuffers)
+	}
+
+	// SwapTotal should be non-negative (swap may be disabled)
+	if data.SwapTotal < 0 {
+		t.Errorf("SwapTotal should be non-negative, got %f", data.SwapTotal)
+	}
+
+	// If there's swap, check swap values
+	if data.SwapTotal > 0 {
+		if data.SwapFree < 0 {
+			t.Errorf("SwapFree should be non-negative, got %f", data.SwapFree)
+		}
+		if data.SwapUsed < 0 {
+			t.Errorf("SwapUsed should be non-negative, got %f", data.SwapUsed)
+		}
+		if data.SwapFree > data.SwapTotal {
+			t.Errorf("SwapFree (%f) should not exceed SwapTotal (%f)", data.SwapFree, data.SwapTotal)
+		}
+	}
+}
+
+func TestGetVMStats(t *testing.T) {
+	stats, err := getVMStats()
+	if err != nil {
+		t.Fatalf("getVMStats() returned error: %v", err)
+	}
+
+	// Should have some basic stats
+	requiredKeys := []string{
+		"Pages free",
+		"Pages active",
+		"Pages inactive",
+		"Pages wired down",
+	}
+
+	for _, key := range requiredKeys {
+		if _, ok := stats[key]; !ok {
+			t.Errorf("getVMStats() missing expected key: %s", key)
+		}
+	}
+
+	// All values should be non-negative
+	for key, value := range stats {
+		if value < 0 {
+			t.Errorf("getVMStats()[%s] should be non-negative, got %f", key, value)
+		}
+	}
+}
+
+func TestMemoryConsistency(t *testing.T) {
+	data, err := GetMemInfo()
+	if err != nil {
+		t.Fatalf("GetMemInfo() returned error: %v", err)
+	}
+
+	// Basic sanity check: used + free + cached should be close to total
+	// (allowing for some variance due to timing and measurement methods)
+	accounted := data.MemUsed + data.MemFree + data.MemCached
+
+	// Allow 20% variance due to different measurement methods
+	variance := data.MemTotal * 0.2
+	if accounted < data.MemTotal-variance || accounted > data.MemTotal+variance {
+		t.Logf("Memory accounting may be off: Used(%f) + Free(%f) + Cached(%f) = %f, Total = %f",
+			data.MemUsed, data.MemFree, data.MemCached, accounted, data.MemTotal)
+	}
+}

--- a/mem_linux.go
+++ b/mem_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package main
 
 import (

--- a/mem_linux_test.go
+++ b/mem_linux_test.go
@@ -1,0 +1,110 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+)
+
+func TestGetMemInfo(t *testing.T) {
+	data, err := GetMemInfo()
+	if err != nil {
+		t.Fatalf("GetMemInfo() returned error: %v", err)
+	}
+
+	// MemTotal should be positive (system has memory)
+	if data.MemTotal <= 0 {
+		t.Errorf("MemTotal should be positive, got %f", data.MemTotal)
+	}
+
+	// MemUsed should be positive (some memory is always in use)
+	if data.MemUsed <= 0 {
+		t.Errorf("MemUsed should be positive, got %f", data.MemUsed)
+	}
+
+	// MemUsed should be less than MemTotal
+	if data.MemUsed >= data.MemTotal {
+		t.Errorf("MemUsed (%f) should be less than MemTotal (%f)", data.MemUsed, data.MemTotal)
+	}
+
+	// MemFree should be non-negative
+	if data.MemFree < 0 {
+		t.Errorf("MemFree should be non-negative, got %f", data.MemFree)
+	}
+
+	// MemAvailable should be positive and less than or equal to MemTotal
+	if data.MemAvailable <= 0 {
+		t.Errorf("MemAvailable should be positive, got %f", data.MemAvailable)
+	}
+	if data.MemAvailable > data.MemTotal {
+		t.Errorf("MemAvailable (%f) should not exceed MemTotal (%f)", data.MemAvailable, data.MemTotal)
+	}
+
+	// MemCached should be non-negative
+	if data.MemCached < 0 {
+		t.Errorf("MemCached should be non-negative, got %f", data.MemCached)
+	}
+
+	// MemBuffers should be non-negative
+	if data.MemBuffers < 0 {
+		t.Errorf("MemBuffers should be non-negative, got %f", data.MemBuffers)
+	}
+
+	// SwapTotal should be non-negative (swap may be disabled)
+	if data.SwapTotal < 0 {
+		t.Errorf("SwapTotal should be non-negative, got %f", data.SwapTotal)
+	}
+
+	// If there's swap, check swap values
+	if data.SwapTotal > 0 {
+		if data.SwapFree < 0 {
+			t.Errorf("SwapFree should be non-negative, got %f", data.SwapFree)
+		}
+		if data.SwapUsed < 0 {
+			t.Errorf("SwapUsed should be non-negative, got %f", data.SwapUsed)
+		}
+		if data.SwapFree > data.SwapTotal {
+			t.Errorf("SwapFree (%f) should not exceed SwapTotal (%f)", data.SwapFree, data.SwapTotal)
+		}
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantKey  string
+		wantVal  float64
+	}{
+		{"MemTotal:       16384000 kB", "MemTotal", 16384000},
+		{"MemFree:         1234567 kB", "MemFree", 1234567},
+		{"Buffers:              0 kB", "Buffers", 0},
+		{"SwapTotal:      2097152 kB", "SwapTotal", 2097152},
+	}
+
+	for _, tt := range tests {
+		key, val := parseLine(tt.input)
+		if key != tt.wantKey {
+			t.Errorf("parseLine(%q) key = %q, want %q", tt.input, key, tt.wantKey)
+		}
+		if val != tt.wantVal {
+			t.Errorf("parseLine(%q) value = %f, want %f", tt.input, val, tt.wantVal)
+		}
+	}
+}
+
+func TestMemoryConsistency(t *testing.T) {
+	data, err := GetMemInfo()
+	if err != nil {
+		t.Fatalf("GetMemInfo() returned error: %v", err)
+	}
+
+	// Basic sanity check: used + free + cached + buffers should be close to total
+	accounted := data.MemUsed + data.MemFree + data.MemCached + data.MemBuffers
+
+	// Allow 20% variance
+	variance := data.MemTotal * 0.2
+	if accounted < data.MemTotal-variance || accounted > data.MemTotal+variance {
+		t.Logf("Memory accounting may be off: Used(%f) + Free(%f) + Cached(%f) + Buffers(%f) = %f, Total = %f",
+			data.MemUsed, data.MemFree, data.MemCached, data.MemBuffers, accounted, data.MemTotal)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strconv"
-	"syscall"
-	"unsafe"
+
+	"golang.org/x/term"
 )
 
 // types {{{
@@ -33,27 +34,15 @@ type DrawData struct {
 	SwapUsed int
 }
 
-type winsize struct {
-	Row    uint16
-	Col    uint16
-	Xpixel uint16
-	Ypixel uint16
-}
-
 // }}}
 
 // getTerminalWidth() {{{
 func getTerminalWidth() int {
-	ws := &winsize{}
-	retCode, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(syscall.Stdin),
-		uintptr(syscall.TIOCGWINSZ),
-		uintptr(unsafe.Pointer(ws)))
-
-	if int(retCode) == -1 {
-		panic(errno)
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return 80 // default fallback
 	}
-	return int(ws.Col)
+	return width
 }
 
 // }}}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestToFloat(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"123", 123},
+		{"123.45", 123.45},
+		{"0", 0},
+		{"", 0},
+		{"invalid", 0},
+		{"16384000", 16384000},
+	}
+
+	for _, tt := range tests {
+		got := toFloat(tt.input)
+		if got != tt.want {
+			t.Errorf("toFloat(%q) = %f, want %f", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestToHumanStr(t *testing.T) {
+	tests := []struct {
+		value float64
+		human bool
+		want  string
+	}{
+		{1024, false, "1 M"},       // 1024 KB = 1 MB when not human
+		{2048, false, "2 M"},       // 2048 KB = 2 MB when not human
+		{1024, true, "1.00 M"},     // 1024 KB = 1 MB in human readable
+		{512, true, "512.00 K"},    // 512 KB stays in KB
+		{1048576, true, "1.00 G"},  // 1 GB in human readable
+	}
+
+	for _, tt := range tests {
+		got := toHumanStr(tt.value, tt.human)
+		if got != tt.want {
+			t.Errorf("toHumanStr(%f, %v) = %q, want %q", tt.value, tt.human, got, tt.want)
+		}
+	}
+}
+
+func TestGetTerminalWidth(t *testing.T) {
+	width := getTerminalWidth()
+	// Should return a reasonable value (fallback is 80)
+	if width <= 0 {
+		t.Errorf("getTerminalWidth() = %d, want positive value", width)
+	}
+	// Should be at least the fallback value or more if terminal is wider
+	// In a test environment, we might get 80 (fallback)
+	if width < 10 || width > 1000 {
+		t.Errorf("getTerminalWidth() = %d, seems unreasonable", width)
+	}
+}


### PR DESCRIPTION
## Summary

- Add macOS support using platform-specific build tags (`//go:build darwin` and `//go:build linux`)
- Implement memory reading via `vm_stat` command and `sysctl` system calls for macOS
- Add `darwin-amd64` and `darwin-arm64` build targets to Makefile  
- Use `golang.org/x/term` for cross-platform terminal width detection
- Add comprehensive tests for both platforms

## Changes

| File | Change |
|------|--------|
| `mem.go` → `mem_linux.go` | Renamed, added `//go:build linux` |
| `mem_darwin.go` | New - macOS memory via vm_stat/sysctl |
| `mem_darwin_test.go` | New - macOS tests |
| `mem_linux_test.go` | New - Linux tests |
| `utils_test.go` | New - utility tests |
| `utils.go` | Use `golang.org/x/term` for terminal width |
| `Makefile` | Add darwin-amd64, darwin-arm64 targets |
| `go.mod` | Add golang.org/x/sys, golang.org/x/term |

## Test plan

- [x] All tests pass on macOS (`go test -v ./...`)
- [x] Cross-compilation succeeds for all targets (`make build`)
- [x] Native macOS binary runs correctly and displays memory info

🤖 Generated with [Claude Code](https://claude.com/claude-code)